### PR TITLE
Support non-ASCII characters for enclosures.

### DIFF
--- a/count-para.lua
+++ b/count-para.lua
@@ -135,10 +135,10 @@ function countPara (doc)
 
       -- format number to insert
       local number = ID
-      if enclosing:len() == 1 then
+      if pandoc.text.len(enclosing) == 1 then
         number = enclosing..ID..enclosing
       else
-        number = enclosing:sub(1,1)..ID..enclosing:sub(2,2)
+        number = pandoc.text.sub(enclosing, 1, 1)..ID..pandoc.text.sub(enclosing, 2, 2)
       end
 
       -- check for user-inserted ids at the start of the paragraph


### PR DESCRIPTION
Use `pandoc.text.len()` and `pandoc.text.sub()` instead of the byte-oriented standard Lua functions.

This allows you to use characters like §, ¶, or angle brackets ⟨⟩.